### PR TITLE
Changes install docs to point to proper account

### DIFF
--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -2,9 +2,9 @@
 
 **There are two ways to start a WebXR enabled project using Unity.**
 
-1. **[Download the example project](https://github.com/mozilla/unity-webxr-export/archive/master.zip).**
+1. **[Download the example project](https://github.com/MozillaReality/unity-webxr-export/archive/master.zip).**
 
-    This is the simplest option, to do this, [download the project](https://github.com/mozilla/unity-webxr-export/archive/master.zip) and open in Unity. You can follow steps from [step #7](#7-build-your-project-to-webxr) onwards to build the project to WebXR.
+    This is the simplest option, to do this, [download the project](https://github.com/MozillaReality/unity-webxr-export/archive/master.zip) and open in Unity. You can follow steps from [step #7](#7-build-your-project-to-webxr) onwards to build the project to WebXR.
 
 2. **[Start by Creating a new Unity 3D Project](#1-create-a-new-unity-3d-project).**
 


### PR DESCRIPTION
Thanks so much for this awesome tool! I noticed in the setup process docs that a link was returning Not Found. This seems due to the account changing to `MozillaReality`. The other links redirect, but this zip in particular did not. This PR should fix it. :) 